### PR TITLE
mac address fixes, better resource reads, general robustness

### DIFF
--- a/internal/provider/dhcpv4_apply_resource.go
+++ b/internal/provider/dhcpv4_apply_resource.go
@@ -15,7 +15,10 @@ import (
 	"github.com/marshallford/terraform-provider-pfsense/pkg/pfsense"
 )
 
-var _ resource.Resource = &DHCPv4ApplyResource{}
+var (
+	_ resource.Resource              = (*DHCPv4ApplyResource)(nil)
+	_ resource.ResourceWithConfigure = (*DHCPv4ApplyResource)(nil)
+)
 
 func NewDHCPv4ApplyResource() resource.Resource { //nolint:ireturn
 	return &DHCPv4ApplyResource{}

--- a/internal/provider/dhcpv4_staticmapping_common.go
+++ b/internal/provider/dhcpv4_staticmapping_common.go
@@ -27,7 +27,7 @@ type DHCPv4StaticMappingsModel struct {
 
 type DHCPv4StaticMappingModel struct {
 	Interface           types.String         `tfsdk:"interface"`
-	MACAddress          types.String         `tfsdk:"mac_address"`
+	MACAddress          macAddressValue      `tfsdk:"mac_address"`
 	ClientIdentifier    types.String         `tfsdk:"client_identifier"`
 	IPAddress           types.String         `tfsdk:"ip_address"`
 	ARPTableStaticEntry types.Bool           `tfsdk:"arp_table_static_entry"`
@@ -93,7 +93,7 @@ func (DHCPv4StaticMappingModel) descriptions() map[string]attrDescription {
 func (DHCPv4StaticMappingModel) AttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"interface":              types.StringType,
-		"mac_address":            types.StringType,
+		"mac_address":            macAddressType{},
 		"client_identifier":      types.StringType,
 		"ip_address":             types.StringType,
 		"arp_table_static_entry": types.BoolType,
@@ -130,7 +130,7 @@ func (m *DHCPv4StaticMappingModel) Set(ctx context.Context, staticMapping pfsens
 	var diags diag.Diagnostics
 
 	m.Interface = types.StringValue(staticMapping.Interface)
-	m.MACAddress = types.StringValue(staticMapping.MACAddress.String())
+	m.MACAddress = newMACAddressValue(staticMapping.MACAddress.String())
 
 	if staticMapping.ClientIdentifier != "" {
 		m.ClientIdentifier = types.StringValue(staticMapping.ClientIdentifier)

--- a/internal/provider/dhcpv4_staticmapping_resource.go
+++ b/internal/provider/dhcpv4_staticmapping_resource.go
@@ -336,4 +336,5 @@ func (r *DHCPv4StaticMappingResource) ImportState(ctx context.Context, req resou
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("interface"), types.StringValue(staticMapping.Interface))...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("mac_address"), newMACAddressValue(staticMapping.MACAddress.String()))...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("apply"), types.BoolValue(defaultApply))...)
 }

--- a/internal/provider/dhcpv4_staticmappings_data_source.go
+++ b/internal/provider/dhcpv4_staticmappings_data_source.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	_ datasource.DataSource              = &DHCPv4StaticMappingsDataSource{}
-	_ datasource.DataSourceWithConfigure = &DHCPv4StaticMappingsDataSource{}
+	_ datasource.DataSource              = (*DHCPv4StaticMappingsDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*DHCPv4StaticMappingsDataSource)(nil)
 )
 
 func NewDHCPv4StaticMappingsDataSource() datasource.DataSource { //nolint:ireturn
@@ -52,6 +52,7 @@ func (d *DHCPv4StaticMappingsDataSource) Schema(_ context.Context, _ datasource.
 						},
 						"mac_address": schema.StringAttribute{
 							Description: DHCPv4StaticMappingModel{}.descriptions()["mac_address"].Description,
+							CustomType:  macAddressType{},
 							Computed:    true,
 						},
 						"client_identifier": schema.StringAttribute{

--- a/internal/provider/dnsresolver_apply_resource.go
+++ b/internal/provider/dnsresolver_apply_resource.go
@@ -14,7 +14,10 @@ import (
 	"github.com/marshallford/terraform-provider-pfsense/pkg/pfsense"
 )
 
-var _ resource.Resource = &DNSResolverApplyResource{}
+var (
+	_ resource.Resource              = (*DNSResolverApplyResource)(nil)
+	_ resource.ResourceWithConfigure = (*DNSResolverApplyResource)(nil)
+)
 
 func NewDNSResolverApplyResource() resource.Resource { //nolint:ireturn
 	return &DNSResolverApplyResource{}

--- a/internal/provider/dnsresolver_configfile_resource.go
+++ b/internal/provider/dnsresolver_configfile_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -17,8 +18,9 @@ import (
 )
 
 var (
-	_ resource.Resource                = &DNSResolverConfigFileResource{}
-	_ resource.ResourceWithImportState = &DNSResolverConfigFileResource{}
+	_ resource.Resource                = (*DNSResolverConfigFileResource)(nil)
+	_ resource.ResourceWithConfigure   = (*DNSResolverConfigFileResource)(nil)
+	_ resource.ResourceWithImportState = (*DNSResolverConfigFileResource)(nil)
 )
 
 type DNSResolverConfigFileResourceModel struct {
@@ -124,6 +126,13 @@ func (r *DNSResolverConfigFileResource) Read(ctx context.Context, req resource.R
 	}
 
 	configFile, err := r.client.GetDNSResolverConfigFile(ctx, data.Name.ValueString())
+
+	if errors.Is(err, pfsense.ErrNotFound) {
+		resp.State.RemoveResource(ctx)
+
+		return
+	}
+
 	if addError(&resp.Diagnostics, "Error reading config file", err) {
 		return
 	}

--- a/internal/provider/dnsresolver_configfile_resource.go
+++ b/internal/provider/dnsresolver_configfile_resource.go
@@ -203,4 +203,5 @@ func (r *DNSResolverConfigFileResource) Delete(ctx context.Context, req resource
 
 func (r *DNSResolverConfigFileResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("apply"), types.BoolValue(defaultApply))...)
 }

--- a/internal/provider/dnsresolver_domainoverride_resource.go
+++ b/internal/provider/dnsresolver_domainoverride_resource.go
@@ -223,4 +223,5 @@ func (r *DNSResolverDomainOverrideResource) Delete(ctx context.Context, req reso
 
 func (r *DNSResolverDomainOverrideResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("domain"), req, resp)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("apply"), types.BoolValue(defaultApply))...)
 }

--- a/internal/provider/dnsresolver_domainoverride_resource.go
+++ b/internal/provider/dnsresolver_domainoverride_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -17,8 +18,9 @@ import (
 )
 
 var (
-	_ resource.Resource                = &DNSResolverDomainOverrideResource{}
-	_ resource.ResourceWithImportState = &DNSResolverDomainOverrideResource{}
+	_ resource.Resource                = (*DNSResolverDomainOverrideResource)(nil)
+	_ resource.ResourceWithConfigure   = (*DNSResolverDomainOverrideResource)(nil)
+	_ resource.ResourceWithImportState = (*DNSResolverDomainOverrideResource)(nil)
 )
 
 type DNSResolverDomainOverrideResourceModel struct {
@@ -144,6 +146,13 @@ func (r *DNSResolverDomainOverrideResource) Read(ctx context.Context, req resour
 	}
 
 	domainOverride, err := r.client.GetDNSResolverDomainOverride(ctx, data.Domain.ValueString())
+
+	if errors.Is(err, pfsense.ErrNotFound) {
+		resp.State.RemoveResource(ctx)
+
+		return
+	}
+
 	if addError(&resp.Diagnostics, "Error reading domain override", err) {
 		return
 	}

--- a/internal/provider/dnsresolver_domainoverrides_data_source.go
+++ b/internal/provider/dnsresolver_domainoverrides_data_source.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	_ datasource.DataSource              = &DNSResolverDomainOverridesDataSource{}
-	_ datasource.DataSourceWithConfigure = &DNSResolverDomainOverridesDataSource{}
+	_ datasource.DataSource              = (*DNSResolverDomainOverridesDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*DNSResolverDomainOverridesDataSource)(nil)
 )
 
 func NewDNSResolverDomainOverridesDataSource() datasource.DataSource { //nolint:ireturn

--- a/internal/provider/dnsresolver_hostoverride_resource.go
+++ b/internal/provider/dnsresolver_hostoverride_resource.go
@@ -287,4 +287,5 @@ func (r *DNSResolverHostOverrideResource) ImportState(ctx context.Context, req r
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain"), types.StringValue(hostOverride.Domain))...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("fqdn"), types.StringValue(hostOverride.FQDN()))...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("apply"), types.BoolValue(defaultApply))...)
 }

--- a/internal/provider/dnsresolver_hostoverride_resource.go
+++ b/internal/provider/dnsresolver_hostoverride_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -21,8 +22,9 @@ import (
 )
 
 var (
-	_ resource.Resource                = &DNSResolverHostOverrideResource{}
-	_ resource.ResourceWithImportState = &DNSResolverHostOverrideResource{}
+	_ resource.Resource                = (*DNSResolverHostOverrideResource)(nil)
+	_ resource.ResourceWithConfigure   = (*DNSResolverHostOverrideResource)(nil)
+	_ resource.ResourceWithImportState = (*DNSResolverHostOverrideResource)(nil)
 )
 
 type DNSResolverHostOverrideResourceModel struct {
@@ -183,6 +185,13 @@ func (r *DNSResolverHostOverrideResource) Read(ctx context.Context, req resource
 	}
 
 	hostOverride, err := r.client.GetDNSResolverHostOverride(ctx, data.FQDN.ValueString())
+
+	if errors.Is(err, pfsense.ErrNotFound) {
+		resp.State.RemoveResource(ctx)
+
+		return
+	}
+
 	if addError(&resp.Diagnostics, "Error reading host override", err) {
 		return
 	}
@@ -269,13 +278,13 @@ func (r *DNSResolverHostOverrideResource) ImportState(ctx context.Context, req r
 		if addError(&resp.Diagnostics, "Host cannot be parsed", hostOverride.SetHost(idParts[0])) {
 			return
 		}
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("host"), hostOverride.Host)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("host"), types.StringValue(hostOverride.Host))...)
 	}
 
 	if addError(&resp.Diagnostics, "Domain cannot be parsed", hostOverride.SetDomain(idParts[1])) {
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain"), hostOverride.Domain)...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("fqdn"), hostOverride.FQDN())...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain"), types.StringValue(hostOverride.Domain))...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("fqdn"), types.StringValue(hostOverride.FQDN()))...)
 }

--- a/internal/provider/dnsresolver_hostoverrides_data_source.go
+++ b/internal/provider/dnsresolver_hostoverrides_data_source.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	_ datasource.DataSource              = &DNSResolverHostOverridesDataSource{}
-	_ datasource.DataSourceWithConfigure = &DNSResolverHostOverridesDataSource{}
+	_ datasource.DataSource              = (*DNSResolverHostOverridesDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*DNSResolverHostOverridesDataSource)(nil)
 )
 
 func NewDNSResolverHostOverridesDataSource() datasource.DataSource { //nolint:ireturn

--- a/internal/provider/execute_php_command_data_source.go
+++ b/internal/provider/execute_php_command_data_source.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	_ datasource.DataSource              = &ExecutePHPCommandDataSource{}
-	_ datasource.DataSourceWithConfigure = &ExecutePHPCommandDataSource{}
+	_ datasource.DataSource              = (*ExecutePHPCommandDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*ExecutePHPCommandDataSource)(nil)
 )
 
 func NewExecutePHPCommandDataSource() datasource.DataSource { //nolint:ireturn

--- a/internal/provider/execute_php_command_resource.go
+++ b/internal/provider/execute_php_command_resource.go
@@ -15,7 +15,10 @@ import (
 	"github.com/marshallford/terraform-provider-pfsense/pkg/pfsense"
 )
 
-var _ resource.Resource = &ExecutePHPCommandResource{}
+var (
+	_ resource.Resource              = (*ExecutePHPCommandResource)(nil)
+	_ resource.ResourceWithConfigure = (*ExecutePHPCommandResource)(nil)
+)
 
 type ExecutePHPCommandResourceModel struct {
 	ExecutePHPCommandModel

--- a/internal/provider/firewall_aliases_data_source.go
+++ b/internal/provider/firewall_aliases_data_source.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	_ datasource.DataSource              = &FirewallAliasesDataSource{}
-	_ datasource.DataSourceWithConfigure = &FirewallAliasesDataSource{}
+	_ datasource.DataSource              = (*FirewallAliasesDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*FirewallAliasesDataSource)(nil)
 )
 
 type FirewallAliasesModel struct {

--- a/internal/provider/firewall_filter_reload_resource.go
+++ b/internal/provider/firewall_filter_reload_resource.go
@@ -14,7 +14,10 @@ import (
 	"github.com/marshallford/terraform-provider-pfsense/pkg/pfsense"
 )
 
-var _ resource.Resource = &FirewallFilterReloadResource{}
+var (
+	_ resource.Resource              = (*FirewallFilterReloadResource)(nil)
+	_ resource.ResourceWithConfigure = (*FirewallFilterReloadResource)(nil)
+)
 
 func NewFirewallFilterReloadResource() resource.Resource { //nolint:ireturn
 	return &FirewallFilterReloadResource{}

--- a/internal/provider/firewall_ip_alias_resource.go
+++ b/internal/provider/firewall_ip_alias_resource.go
@@ -244,4 +244,5 @@ func (r *FirewallIPAliasResource) Delete(ctx context.Context, req resource.Delet
 
 func (r *FirewallIPAliasResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("apply"), types.BoolValue(defaultApply))...)
 }

--- a/internal/provider/firewall_ip_alias_resource.go
+++ b/internal/provider/firewall_ip_alias_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -19,8 +20,9 @@ import (
 )
 
 var (
-	_ resource.Resource                = &FirewallIPAliasResource{}
-	_ resource.ResourceWithImportState = &FirewallIPAliasResource{}
+	_ resource.Resource                = (*FirewallIPAliasResource)(nil)
+	_ resource.ResourceWithConfigure   = (*FirewallIPAliasResource)(nil)
+	_ resource.ResourceWithImportState = (*FirewallIPAliasResource)(nil)
 )
 
 type FirewallIPAliasResourceModel struct {
@@ -165,11 +167,18 @@ func (r *FirewallIPAliasResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	ipAlias, err := r.client.GetFirewallIPAlias(ctx, data.Name.ValueString())
+
+	if errors.Is(err, pfsense.ErrNotFound) {
+		resp.State.RemoveResource(ctx)
+
+		return
+	}
+
 	if addError(&resp.Diagnostics, "Error reading IP alias", err) {
 		return
 	}
 
-	resp.Diagnostics.Append(data.Value(ctx, ipAlias)...)
+	resp.Diagnostics.Append(data.Set(ctx, *ipAlias)...)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/firewall_port_alias_resource.go
+++ b/internal/provider/firewall_port_alias_resource.go
@@ -233,4 +233,5 @@ func (r *FirewallPortAliasResource) Delete(ctx context.Context, req resource.Del
 
 func (r *FirewallPortAliasResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("name"), req, resp)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("apply"), types.BoolValue(defaultApply))...)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -15,7 +15,7 @@ import (
 	"github.com/marshallford/terraform-provider-pfsense/pkg/pfsense"
 )
 
-var _ provider.Provider = &pfSenseProvider{}
+var _ provider.Provider = (*pfSenseProvider)(nil)
 
 func New(version string) func() provider.Provider {
 	return func() provider.Provider {

--- a/internal/provider/provider_custom_types.go
+++ b/internal/provider/provider_custom_types.go
@@ -1,0 +1,176 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/marshallford/terraform-provider-pfsense/pkg/pfsense"
+)
+
+var (
+	_             basetypes.StringTypable                    = (*macAddressType)(nil)
+	_             basetypes.StringValuable                   = (*macAddressValue)(nil)
+	_             basetypes.StringValuableWithSemanticEquals = (*macAddressValue)(nil)
+	_             xattr.ValidateableAttribute                = (*macAddressValue)(nil)
+	errCustomType                                            = errors.New("custom type")
+)
+
+type macAddressType struct {
+	basetypes.StringType
+}
+
+func (t macAddressType) String() string {
+	return "macAddressType"
+}
+
+func (t macAddressType) ValueType(ctx context.Context) attr.Value { //nolint:ireturn
+	return macAddressValue{}
+}
+
+func (t macAddressType) Equal(o attr.Type) bool {
+	other, ok := o.(macAddressType)
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+func (t macAddressType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) { //nolint:ireturn
+	return macAddressValue{
+		StringValue: in,
+	}, nil
+}
+
+func (t macAddressType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) { //nolint:ireturn
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("mac address %w: unexpected value type of %T", errCustomType, attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("mac address %w: unexpected error converting StringValue to StringValuable: %v", errCustomType, diags)
+	}
+
+	return stringValuable, nil
+}
+
+type macAddressValue struct {
+	basetypes.StringValue
+}
+
+func (v macAddressValue) Type(_ context.Context) attr.Type { //nolint:ireturn
+	return macAddressType{}
+}
+
+func (v macAddressValue) Equal(o attr.Value) bool {
+	other, ok := o.(macAddressValue)
+
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+func (v macAddressValue) StringSemanticEquals(_ context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(macAddressValue)
+	if !ok {
+		summary, detail := unexpectedValueTypeSemanticEquality(v, newValuable)
+		diags.AddError(summary, detail)
+
+		return false, diags
+	}
+
+	newValueHwAddr, err := pfsense.ParseMACAddress(v.ValueString())
+	if err != nil {
+		summary, detail := unexpectedErrorSemanticEquality(err)
+		diags.AddError(summary, detail)
+	}
+
+	valueHwAddr, err := pfsense.ParseMACAddress(newValue.ValueString())
+	if err != nil {
+		summary, detail := unexpectedErrorSemanticEquality(err)
+		diags.AddError(summary, detail)
+	}
+
+	if diags.HasError() {
+		return false, diags
+	}
+
+	return pfsense.CompareMACAddresses(newValueHwAddr, valueHwAddr), diags
+}
+
+func (v macAddressValue) ValidateAttribute(ctx context.Context, req xattr.ValidateAttributeRequest, resp *xattr.ValidateAttributeResponse) {
+	if v.IsUnknown() || v.IsNull() {
+		return
+	}
+
+	err := pfsense.ValidateMACAddress(v.ValueString())
+	addPathError(&resp.Diagnostics, req.Path, "Not a valid MAC address", err)
+}
+
+func (v macAddressValue) parseMACAddress() (net.HardwareAddr, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if v.IsNull() {
+		addError(&diags, "MAC Address Parse Error", fmt.Errorf("mac address %w: value is null", errCustomType))
+
+		return nil, diags
+	}
+
+	if v.IsUnknown() {
+		addError(&diags, "MAC Address Parse Error", fmt.Errorf("mac address %w: value is unknown", errCustomType))
+
+		return nil, diags
+	}
+
+	hwAddr, err := pfsense.ParseMACAddress(v.ValueString())
+	if err != nil {
+		addError(&diags, "MAC Address Parse Error", err)
+
+		return nil, diags
+	}
+
+	return hwAddr, diags
+}
+
+// func newMACAddressNull() macAddressValue {
+// 	return macAddressValue{
+// 		StringValue: basetypes.NewStringNull(),
+// 	}
+// }
+
+// func newMACAddressUnknown() macAddressValue {
+// 	return macAddressValue{
+// 		StringValue: basetypes.NewStringUnknown(),
+// 	}
+// }
+
+func newMACAddressValue(value string) macAddressValue {
+	return macAddressValue{
+		StringValue: basetypes.NewStringValue(value),
+	}
+}
+
+// func newMACAddressPointerValue(value *string) macAddressValue {
+// 	return macAddressValue{
+// 		StringValue: basetypes.NewStringPointerValue(value),
+// 	}
+// }

--- a/internal/provider/provider_plan_modifiers.go
+++ b/internal/provider/provider_plan_modifiers.go
@@ -1,0 +1,57 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/marshallford/terraform-provider-pfsense/pkg/pfsense"
+)
+
+type macAddressModifier struct{}
+
+var (
+	_ planmodifier.String = (*macAddressModifier)(nil)
+)
+
+func (m macAddressModifier) Description(_ context.Context) string {
+	return "Compares MAC addresses semantically regardless of format"
+}
+
+func (m macAddressModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m macAddressModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+
+	stateValue := req.StateValue.ValueString()
+	planValue := req.PlanValue.ValueString()
+
+	if stateValue == planValue {
+		return
+	}
+
+	stateHwAddr, err := pfsense.ParseMACAddress(stateValue)
+	if addPathWarning(&resp.Diagnostics, req.Path, "Invalid MAC address in state", err) {
+		return
+	}
+
+	planHwAddr, err := pfsense.ParseMACAddress(planValue)
+	if addPathError(&resp.Diagnostics, req.Path, "Invalid MAC address in plan", err) {
+		return
+	}
+
+	if pfsense.CompareMACAddresses(stateHwAddr, planHwAddr) {
+		resp.PlanValue = req.StateValue
+	}
+}
+
+func macAddressPlanModifier() macAddressModifier {
+	return macAddressModifier{}
+}

--- a/internal/provider/provider_utils.go
+++ b/internal/provider/provider_utils.go
@@ -40,6 +40,21 @@ func unexpectedConfigureType(value string, providerData any) (string, string) {
 		fmt.Sprintf("Expected *providerOptions, got: %T. Please report this issue to the provider developers.", providerData)
 }
 
+func unexpectedValueTypeSemanticEquality(value any, valuable any) (string, string) {
+	return "Semantic Equality Check Error",
+		fmt.Sprintf("An unexpected value type was received while performing semantic equality checks. "+
+			"Please report this to the provider developers.\n\n"+
+			"Expected Value Type: %T\n"+
+			"Got Value Type: %T", value, valuable)
+}
+
+func unexpectedErrorSemanticEquality(err error) (string, string) {
+	return "Semantic Equality Check Error",
+		fmt.Sprintf("An unexpected error occurred while performing semantic equality checks. "+
+			"Please report this to the provider developers.\n\n"+
+			"Error: %s", err.Error())
+}
+
 func configureResourceClient(req resource.ConfigureRequest, resp *resource.ConfigureResponse) (*pfsense.Client, bool) {
 	if req.ProviderData == nil {
 		return nil, false
@@ -95,7 +110,7 @@ func addError(diags *diag.Diagnostics, summary string, err error) bool {
 	return false
 }
 
-func addPathError(diags *diag.Diagnostics, path path.Path, summary string, err error) bool { //nolint:unparam
+func addPathError(diags *diag.Diagnostics, path path.Path, summary string, err error) bool {
 	if err != nil {
 		diags.AddAttributeError(path, summary, fmt.Sprintf("%s: %s", diagDetailPrefix, err))
 
@@ -108,6 +123,16 @@ func addPathError(diags *diag.Diagnostics, path path.Path, summary string, err e
 func addWarning(diags *diag.Diagnostics, summary string, err error) bool { //nolint:unparam
 	if err != nil {
 		diags.AddWarning(summary, fmt.Sprintf("%s: %s", diagDetailPrefix, err))
+
+		return true
+	}
+
+	return false
+}
+
+func addPathWarning(diags *diag.Diagnostics, path path.Path, summary string, err error) bool {
+	if err != nil {
+		diags.AddAttributeWarning(path, summary, fmt.Sprintf("%s: %s", diagDetailPrefix, err))
 
 		return true
 	}

--- a/internal/provider/system_version_data_source.go
+++ b/internal/provider/system_version_data_source.go
@@ -11,8 +11,8 @@ import (
 )
 
 var (
-	_ datasource.DataSource              = &SystemVersionDataSource{}
-	_ datasource.DataSourceWithConfigure = &SystemVersionDataSource{}
+	_ datasource.DataSource              = (*SystemVersionDataSource)(nil)
+	_ datasource.DataSourceWithConfigure = (*SystemVersionDataSource)(nil)
 )
 
 func NewSystemVersionDataSource() datasource.DataSource { //nolint:ireturn

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -10,6 +10,8 @@ import (
 
 type stringIsDNSLabelValidator struct{}
 
+var _ validator.String = (*stringIsDNSLabelValidator)(nil)
+
 func (v stringIsDNSLabelValidator) Description(_ context.Context) string {
 	return "string must be a RFC 1123 DNS label"
 }
@@ -32,6 +34,8 @@ func stringIsDNSLabel() stringIsDNSLabelValidator {
 }
 
 type stringIsDomainValidator struct{}
+
+var _ validator.String = (*stringIsDomainValidator)(nil)
 
 func (v stringIsDomainValidator) Description(_ context.Context) string {
 	return "string must be a domain"
@@ -56,6 +60,8 @@ func stringIsDomain() stringIsDomainValidator {
 
 type stringIsAliasValidator struct{}
 
+var _ validator.String = (*stringIsAliasValidator)(nil)
+
 func (v stringIsAliasValidator) Description(_ context.Context) string {
 	return "string must be a pfsense alias"
 }
@@ -78,6 +84,8 @@ func stringIsAlias() stringIsAliasValidator {
 }
 
 type stringIsConfigFileNameValidator struct{}
+
+var _ validator.String = (*stringIsConfigFileNameValidator)(nil)
 
 func (v stringIsConfigFileNameValidator) Description(_ context.Context) string {
 	return "string must be a config file name"
@@ -102,6 +110,8 @@ func stringIsConfigFileName() stringIsConfigFileNameValidator {
 
 type stringIsInterfaceValidator struct{}
 
+var _ validator.String = (*stringIsInterfaceValidator)(nil)
+
 func (v stringIsInterfaceValidator) Description(_ context.Context) string {
 	return "string must be a pfsense interface"
 }
@@ -123,30 +133,9 @@ func stringIsInterface() stringIsInterfaceValidator {
 	return stringIsInterfaceValidator{}
 }
 
-type stringIsMACAddressValidator struct{}
-
-func (v stringIsMACAddressValidator) Description(_ context.Context) string {
-	return "string must be a MAC address"
-}
-
-func (v stringIsMACAddressValidator) MarkdownDescription(ctx context.Context) string {
-	return v.Description(ctx)
-}
-
-func (v stringIsMACAddressValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
-	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
-		return
-	}
-
-	err := pfsense.ValidateMACAddress(req.ConfigValue.ValueString())
-	addPathError(&resp.Diagnostics, req.Path, "Not a valid MAC address", err)
-}
-
-func stringIsMACAddress() stringIsMACAddressValidator {
-	return stringIsMACAddressValidator{}
-}
-
 type stringIsPortValidator struct{}
+
+var _ validator.String = (*stringIsPortValidator)(nil)
 
 func (v stringIsPortValidator) Description(_ context.Context) string {
 	return "string must be a port number"
@@ -170,6 +159,8 @@ func stringIsPort() stringIsPortValidator {
 }
 
 type stringIsPortRangeValidator struct{}
+
+var _ validator.String = (*stringIsPortRangeValidator)(nil)
 
 func (v stringIsPortRangeValidator) Description(_ context.Context) string {
 	return "string must be a port range"
@@ -195,6 +186,8 @@ func stringIsPortRange() stringIsPortRangeValidator {
 type stringIsIPAddressValidator struct {
 	AddressFamily string
 }
+
+var _ validator.String = (*stringIsIPAddressValidator)(nil)
 
 func (v stringIsIPAddressValidator) Description(_ context.Context) string {
 	if v.AddressFamily == "Any" {
@@ -231,6 +224,8 @@ func stringIsIPAddress(addrFamily string) stringIsIPAddressValidator {
 
 type stringIsIPAddressPortValidator struct{}
 
+var _ validator.String = (*stringIsIPAddressPortValidator)(nil)
+
 func (v stringIsIPAddressPortValidator) Description(_ context.Context) string {
 	return "string must be an ip address port"
 }
@@ -253,6 +248,8 @@ func stringIsIPAddressPort() stringIsIPAddressPortValidator {
 }
 
 type stringIsNetworkValidator struct{}
+
+var _ validator.String = (*stringIsNetworkValidator)(nil)
 
 func (v stringIsNetworkValidator) Description(_ context.Context) string {
 	return "string must be a network"

--- a/pkg/pfsense/dhcpv4_staticmapping.go
+++ b/pkg/pfsense/dhcpv4_staticmapping.go
@@ -226,9 +226,9 @@ func (sm *DHCPv4StaticMapping) SetMaximumLeaseTime(maximumLeaseTime string) erro
 
 type DHCPv4StaticMappings []DHCPv4StaticMapping
 
-func (sms DHCPv4StaticMappings) GetByMACAddress(macAddress string) (*DHCPv4StaticMapping, error) {
+func (sms DHCPv4StaticMappings) GetByMACAddress(macAddress net.HardwareAddr) (*DHCPv4StaticMapping, error) {
 	for _, sm := range sms {
-		if sm.MACAddress.String() == macAddress {
+		if sm.MACAddress.String() == macAddress.String() {
 			return &sm, nil
 		}
 	}
@@ -236,9 +236,9 @@ func (sms DHCPv4StaticMappings) GetByMACAddress(macAddress string) (*DHCPv4Stati
 	return nil, fmt.Errorf("static mapping %w with mac address '%s'", ErrNotFound, macAddress)
 }
 
-func (sms DHCPv4StaticMappings) GetControlIDByMACAddress(macAddress string) (*int, error) {
+func (sms DHCPv4StaticMappings) GetControlIDByMACAddress(macAddress net.HardwareAddr) (*int, error) {
 	for index, do := range sms {
-		if do.MACAddress.String() == macAddress {
+		if do.MACAddress.String() == macAddress.String() {
 			return &index, nil
 		}
 	}
@@ -335,7 +335,7 @@ func (pf *Client) GetDHCPv4StaticMappings(ctx context.Context, iface string) (*D
 	return staticMappings, nil
 }
 
-func (pf *Client) GetDHCPv4StaticMapping(ctx context.Context, iface string, macAddress string) (*DHCPv4StaticMapping, error) {
+func (pf *Client) GetDHCPv4StaticMapping(ctx context.Context, iface string, macAddress net.HardwareAddr) (*DHCPv4StaticMapping, error) {
 	defer pf.read(&pf.mutexes.DHCPv4StaticMapping)()
 
 	staticMappings, err := pf.getDHCPv4StaticMappings(ctx, iface)
@@ -408,7 +408,7 @@ func (pf *Client) CreateDHCPv4StaticMapping(ctx context.Context, staticMappingRe
 		return nil, fmt.Errorf("%w '%s' static mappings after creating, %w", ErrGetOperationFailed, staticMappingReq.Interface, err)
 	}
 
-	staticMapping, err := staticMappings.GetByMACAddress(staticMappingReq.MACAddress.String())
+	staticMapping, err := staticMappings.GetByMACAddress(staticMappingReq.MACAddress)
 	if err != nil {
 		return nil, fmt.Errorf("%w '%s' static mapping after creating, %w", ErrGetOperationFailed, staticMappingReq.Interface, err)
 	}
@@ -424,7 +424,7 @@ func (pf *Client) UpdateDHCPv4StaticMapping(ctx context.Context, staticMappingRe
 		return nil, fmt.Errorf("%w '%s' static mappings, %w", ErrGetOperationFailed, staticMappingReq.Interface, err)
 	}
 
-	controlID, err := staticMappings.GetControlIDByMACAddress(staticMappingReq.MACAddress.String())
+	controlID, err := staticMappings.GetControlIDByMACAddress(staticMappingReq.MACAddress)
 	if err != nil {
 		return nil, fmt.Errorf("%w '%s' static mapping, %w", ErrGetOperationFailed, staticMappingReq.Interface, err)
 	}
@@ -438,7 +438,7 @@ func (pf *Client) UpdateDHCPv4StaticMapping(ctx context.Context, staticMappingRe
 		return nil, fmt.Errorf("%w '%s' static mappings after creating, %w", ErrGetOperationFailed, staticMappingReq.Interface, err)
 	}
 
-	staticMapping, err := staticMappings.GetByMACAddress(staticMappingReq.MACAddress.String())
+	staticMapping, err := staticMappings.GetByMACAddress(staticMappingReq.MACAddress)
 	if err != nil {
 		return nil, fmt.Errorf("%w '%s' static mapping after creating, %w", ErrGetOperationFailed, staticMappingReq.Interface, err)
 	}
@@ -460,7 +460,7 @@ func (pf *Client) deleteDHCPv4StaticMapping(ctx context.Context, iface string, c
 	return err
 }
 
-func (pf *Client) DeleteDHCPv4StaticMapping(ctx context.Context, iface string, macAddress string) error {
+func (pf *Client) DeleteDHCPv4StaticMapping(ctx context.Context, iface string, macAddress net.HardwareAddr) error {
 	defer pf.write(&pf.mutexes.DHCPv4StaticMapping)()
 
 	staticMappings, err := pf.getDHCPv4StaticMappings(ctx, iface)

--- a/pkg/pfsense/utils.go
+++ b/pkg/pfsense/utils.go
@@ -1,0 +1,19 @@
+package pfsense
+
+import (
+	"fmt"
+	"net"
+)
+
+func ParseMACAddress(macAddress string) (net.HardwareAddr, error) {
+	hwAddr, err := net.ParseMAC(macAddress)
+	if err != nil {
+		return nil, fmt.Errorf("%w, not a valid mac address", ErrClientValidation)
+	}
+
+	return hwAddr, nil
+}
+
+func CompareMACAddresses(macAddress1 net.HardwareAddr, macAddress2 net.HardwareAddr) bool {
+	return macAddress1.String() == macAddress2.String()
+}

--- a/pkg/pfsense/validation.go
+++ b/pkg/pfsense/validation.go
@@ -121,10 +121,6 @@ func ValidateMACAddress(macAddress string) error {
 		return fmt.Errorf("%w, not an ieee 802 mac-48 address (6 bytes)", ErrClientValidation)
 	}
 
-	if !strings.Contains(macAddress, ":") {
-		return fmt.Errorf("%w, hex octets must be separated by colons", ErrClientValidation)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Fixes #41, #42.

- MAC address custom type
- MAC address diffing
- dhcpv4_staticmapping import fix
- Improves all resource read methods with `ErrNotFound` check
- IP and Port alias read fix
- Interface guards
- Add apply attr on resource import